### PR TITLE
新增multiple和param参数，支持多选上传和自定义接口返回字段

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ import ElUploadSortable from "../../../node_modules/el-upload-sortable/src/index
 max | 最多可以上传图片数量 | number | 15
 action | 上传图片的api地址 | string | https://jsonplaceholder.typicode.com/posts/
 list | 初始图片列表（可选） | array | []
+multiple | 是否多选（可选） | boolean | false
+param | 上传接口返回结果中图片链接对应的字段（可选），若接口返回结果为{url: 'xxx'}，则传值为"url"，若接口返回结果为{result:{url:'xxx'}}，则传值应为"result.url"，依此类推 | string | ""
 
 ## Events
 

--- a/src/index.ts.vue
+++ b/src/index.ts.vue
@@ -27,6 +27,7 @@
     </div>
   </draggable>
   <el-upload
+    :multiple="multiple"
     v-if="imgList.length < max"
     class="el-upload el-upload--picture-card"
     :action="action"
@@ -54,6 +55,8 @@ export default class ElUploadSortable extends Vue {
   @Prop({ default: 15 }) max!: number;
   @Prop({ default: 'https://jsonplaceholder.typicode.com/posts/' }) action!: string;
   @Prop({ default: () => []}) list!: Array<string>;
+  @Prop({ default: false}) multiple!: boolean;
+  @Prop({ default: ''}) param!: string; // 上传接口返回结果中的图片链接对应的参数，格式如"url"、"result.url"
 
   get imgList() {
     return this.list;
@@ -96,7 +99,12 @@ export default class ElUploadSortable extends Vue {
 
   @Emit('change')
   handleSuccess(res: any, file: any) {
-    this.imgList.push(URL.createObjectURL(file.raw));
+    const params = this.param.split('.');
+    let url = res;
+    params.forEach(item => {
+      url = url[item];
+    });
+    this.imgList.push(url ? url: URL.createObjectURL(file.raw));
     return this.imgList
   }
 

--- a/src/index.vue
+++ b/src/index.vue
@@ -27,6 +27,7 @@
     </div>
   </draggable>
   <el-upload
+    :multiple="multiple"
     v-if="imgList.length < max"
     class="el-upload el-upload--picture-card"
     :action="action"
@@ -61,6 +62,14 @@ export default {
     list: {
       type: Array,
       default: () => []
+    },
+    multiple: {
+      type: Boolean,
+      default: false
+    },
+    param: {
+      type: String,
+      default: ''
     }
   },
 
@@ -110,7 +119,12 @@ export default {
     },
 
     handleSuccess(res, file) {
-      this.imgList.push(URL.createObjectURL(file.raw));
+      const params = this.param.split('.');
+      let url = res;
+      params.forEach(item => {
+        url = url[item];
+      });
+      this.imgList.push(url ? url: URL.createObjectURL(file.raw));
       this.$emit('change', this.imgList)
     },
 


### PR DESCRIPTION
1. 支持多选，默认为单选；
2. 支持传参数：param，表示接口返回结果中图片链接对应的参数，若接口返回结果为{url: 'xxx'}，则传值为"url"，若接口返回结果为{result:{url:'xxx'}}，则传值应为"result.url"，依此类推；若不传该参数，图片链接将使用临时blob url